### PR TITLE
Add a Week-View to Calendar Screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build
 
 on: push
 jobs: 
-  build-and-test: 
+  build-android: 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1 

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -10,7 +10,8 @@ class TodoItem {
   Color color;
   bool done = false;
   bool isRepeating = false;
-  DateTime? time;
+  DateTime? startTime;
+  DateTime? endTime;
   String? location;
   String? link;
   bool isReminder = true;
@@ -29,7 +30,8 @@ class TodoItem {
       this.isRepeating = false,
       this.itemDescription,
       this.color = Colors.green,
-      this.time,
+      this.startTime,
+      this.endTime,
       this.location,
       this.link,
       this.isReminder = true,
@@ -45,8 +47,9 @@ class TodoItem {
       'color': color.value,
       'done': done,
       'isRepeating': isRepeating,
-      'time': time
+      'time': startTime
           ?.millisecondsSinceEpoch, //TODO: come up with some kind of null safety for this
+      'endTime': endTime?.millisecondsSinceEpoch,
       'link': link ?? "",
       'location': location ?? "",
       'isReminder': isReminder,
@@ -65,7 +68,8 @@ class TodoItem {
         color: Color(map['color'] ?? Colors.green.value),
         done: map['done'],
         isRepeating: map['isRepeating'],
-        time: DateTime.fromMillisecondsSinceEpoch(map['time']),
+        startTime: DateTime.fromMillisecondsSinceEpoch(map['time']),
+        endTime: DateTime.fromMillisecondsSinceEpoch(map['time']),
         // DateTime.now()
         // , //FIXME: do some kind of null checking for this
         link: map['link'] ?? "",

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:nudge/providers/calendar_provider.dart';
 import 'package:nudge/providers/items_provider.dart';
 import 'package:nudge/providers/user_provider.dart';
 

--- a/lib/screens/calendar_page.dart
+++ b/lib/screens/calendar_page.dart
@@ -2,14 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:nudge/widgets/appbar.dart';
 import 'package:nudge/widgets/calendar/month_view.dart';
 
-class CalendarPage extends StatefulWidget {
+class CalendarPage extends StatelessWidget {
   const CalendarPage({super.key});
 
-  @override
-  State<CalendarPage> createState() => _CalendarPageState();
-}
-
-class _CalendarPageState extends State<CalendarPage> {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
@@ -17,10 +12,7 @@ class _CalendarPageState extends State<CalendarPage> {
         body: Padding(
           padding: EdgeInsets.all(8.0),
           child: Column(
-            children: [
-              SizedBox(height: 20),
-              MonthView(),
-            ],
+            children: [SizedBox(height: 50), MonthView()],
           ),
         ));
   }

--- a/lib/screens/calendar_page.dart
+++ b/lib/screens/calendar_page.dart
@@ -1,11 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
-import 'package:nudge/models/item.dart';
-import 'package:nudge/providers/calendar_provider.dart';
-import 'package:nudge/providers/items_provider.dart';
 import 'package:nudge/widgets/appbar.dart';
-import 'package:provider/provider.dart';
-import 'package:syncfusion_flutter_calendar/calendar.dart';
+import 'package:nudge/widgets/calendar/month_view.dart';
 
 class CalendarPage extends StatefulWidget {
   const CalendarPage({super.key});
@@ -15,103 +10,18 @@ class CalendarPage extends StatefulWidget {
 }
 
 class _CalendarPageState extends State<CalendarPage> {
-  final now = DateTime.now();
-  DateTime earliest = DateTime.now(), latest = DateTime.now();
-
-  /// find the highest and lowest dates, and get all the dates between
-  void monthSelectionChanged(ViewChangedDetails viewChangedDetails) {
-    earliest = viewChangedDetails.visibleDates[0];
-    latest = viewChangedDetails.visibleDates[0];
-
-    // find the latest and earliest dates
-
-    viewChangedDetails.visibleDates.forEach((element) {
-      if (element.isBefore(earliest)) {
-        earliest = element;
-      }
-
-      if (element.isAfter(latest)) {
-        latest = element;
-      }
-    });
-
-    // add an extra day to latest to ensure it includes all events on the last visible day
-    latest.add(const Duration(days: 1));
-
-    print(earliest.toIso8601String());
-    print(latest.toIso8601String());
-
-    CalendarProvider().updateCalendarView(earliest, latest);
-  }
-
-  @override
-  void initState() {
-    earliest = DateTime(now.year, now.month, 0);
-    latest = DateTime(now.year, now.month + 1, 1);
-    super.initState();
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        bottomNavigationBar: const MyAppBar(),
+    return const Scaffold(
+        bottomNavigationBar: MyAppBar(),
         body: Padding(
-          padding: const EdgeInsets.all(8.0),
+          padding: EdgeInsets.all(8.0),
           child: Column(
             children: [
-              const SizedBox(height: 20),
-              Expanded(child: Consumer<CalendarProvider>(
-                builder: (context, provider, child) {
-                  return SfCalendar(
-                    initialDisplayDate: DateTime.now(),
-                    view: CalendarView.month,
-                    monthViewSettings:
-                        const MonthViewSettings(showAgenda: true),
-                    showNavigationArrow: true,
-                    dataSource: MeetingDataSource(provider.itemsForMonth),
-                    onViewChanged: (viewChangedDetails) {
-                      monthSelectionChanged(viewChangedDetails);
-                    },
-                  );
-                },
-              )),
+              SizedBox(height: 20),
+              MonthView(),
             ],
           ),
         ));
-  }
-}
-
-class MeetingDataSource extends CalendarDataSource {
-  MeetingDataSource(List<TodoItem> source) {
-    appointments = source;
-  }
-
-  @override
-  DateTime getStartTime(int index) {
-    return appointments![index].time;
-  }
-
-  @override
-  DateTime getEndTime(int index) {
-    DateTime end = appointments![index].time;
-
-    end.add(const Duration(hours: 1));
-
-    return end;
-  }
-
-  @override
-  String getSubject(int index) {
-    return appointments![index].itemName;
-  }
-
-  @override
-  Color getColor(int index) {
-    return appointments![index].color;
-  }
-
-  @override
-  bool isAllDay(int index) {
-    return false;
   }
 }

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -139,6 +139,7 @@ class _HomePageState extends State<HomePage> {
                             builder: (context, provider, _) {
                               // provider.todayToDoList
                               //     .forEach((element) => print(element.toMap()));
+
                               return TodoList(
                                   items: provider.todayToDoList,
                                   checkBoxChanged: checkBoxChanged,

--- a/lib/screens/item_page.dart
+++ b/lib/screens/item_page.dart
@@ -61,7 +61,7 @@ class _ItemPageState extends State<ItemPage> {
     color = item.color;
 
     // time
-    selectedDate = item.time ?? DateTime.now();
+    selectedDate = item.startTime ?? DateTime.now();
 
     // bool
     done = item.done;
@@ -82,7 +82,7 @@ class _ItemPageState extends State<ItemPage> {
     item.itemDescription = descriptionController.text;
     item.location = locationController.text;
     item.link = linkController.text;
-    item.time = selectedDate;
+    item.startTime = selectedDate;
     item.isReminder = doNotification;
     item.done = done;
     item.labels = labels.map((e) => e.id).toList();

--- a/lib/screens/item_page.dart
+++ b/lib/screens/item_page.dart
@@ -27,7 +27,8 @@ class _ItemPageState extends State<ItemPage> {
   bool done = false;
   bool doNotification = false;
   DateTime now = DateTime.now();
-  DateTime selectedDate = DateTime.now();
+  DateTime startDateTime = DateTime.now();
+  DateTime endDateTime = DateTime.now().add(Duration(minutes: 30));
   var outputFormat = DateFormat('MMMM dd');
   var timeFormat = DateFormat.Hm();
   bool showTime = false;
@@ -61,7 +62,12 @@ class _ItemPageState extends State<ItemPage> {
     color = item.color;
 
     // time
-    selectedDate = item.startTime ?? DateTime.now();
+    startDateTime = item.startTime ?? DateTime.now();
+    endDateTime = item.endTime ?? DateTime.now().add(Duration(minutes: 30));
+
+    if (item.startTime != null) {
+      showTime = true;
+    }
 
     // bool
     done = item.done;
@@ -70,7 +76,10 @@ class _ItemPageState extends State<ItemPage> {
     // get the labels
     Future.delayed(Duration.zero, () async {
       labels = await LabelsProvider().getLabelsForItem(item);
-      setState(() {});
+
+      if (mounted) {
+        setState(() {}); //FIXME: this line causes an exception
+      }
     });
 
     //TODO: add ui elements for repeating
@@ -82,7 +91,8 @@ class _ItemPageState extends State<ItemPage> {
     item.itemDescription = descriptionController.text;
     item.location = locationController.text;
     item.link = linkController.text;
-    item.startTime = selectedDate;
+    item.startTime = startDateTime;
+    item.endTime = endDateTime;
     item.isReminder = doNotification;
     item.done = done;
     item.labels = labels.map((e) => e.id).toList();
@@ -92,7 +102,8 @@ class _ItemPageState extends State<ItemPage> {
   @override
   void initState() {
     // set selectedDate to start of the day
-    selectedDate = DateTime(now.year, now.month, now.day);
+    startDateTime = DateTime(now.year, now.month, now.day);
+    endDateTime = DateTime(now.year, now.month, now.day);
     setupExistingItem();
     super.initState();
   }
@@ -169,8 +180,9 @@ class _ItemPageState extends State<ItemPage> {
                           Expanded(
                             child: TextFormField(
                               style: TextStyle(
-                                  color: Theme.of(context).colorScheme.tertiary,
-                                  fontSize: 20),
+                                color: Theme.of(context).colorScheme.tertiary,
+                                // fontSize: 20
+                              ),
                               decoration: const InputDecoration(
                                   hintText: "Description ...",
                                   border: InputBorder.none),
@@ -195,11 +207,15 @@ class _ItemPageState extends State<ItemPage> {
                                   firstDate: now,
                                   lastDate: DateTime(2101));
 
+                              // set the date time of the start and end of the task
                               setState(() {
-                                if (test != null) selectedDate = test;
+                                if (test != null) {
+                                  startDateTime = test;
+                                  endDateTime = test;
+                                }
                               });
                             },
-                            child: Text(outputFormat.format(selectedDate),
+                            child: Text(outputFormat.format(startDateTime),
                                 style: TextStyle(
                                     color: Theme.of(context)
                                         .colorScheme
@@ -217,20 +233,49 @@ class _ItemPageState extends State<ItemPage> {
                                       TimeOfDay? chosenTime =
                                           await showTimePicker(
                                               context: context,
-                                              initialTime: TimeOfDay.now());
+                                              initialTime:
+                                                  TimeOfDay.fromDateTime(
+                                                      startDateTime));
 
                                       if (chosenTime != null) {
                                         setState(() {
-                                          selectedDate = DateTime(
-                                              selectedDate.year,
-                                              selectedDate.month,
-                                              selectedDate.day,
+                                          startDateTime = DateTime(
+                                              startDateTime.year,
+                                              startDateTime.month,
+                                              startDateTime.day,
                                               chosenTime.hour,
                                               chosenTime.minute);
                                         });
                                       }
                                     },
-                                    child: Text(timeFormat.format(selectedDate),
+                                    child: Text(
+                                        "Start: ${timeFormat.format(startDateTime)}",
+                                        style: TextStyle(
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .tertiary))),
+                                TextButton(
+                                    onPressed: () async {
+                                      TimeOfDay? chosenTime =
+                                          await showTimePicker(
+                                              context: context,
+                                              initialTime:
+                                                  TimeOfDay.fromDateTime(
+                                                      endDateTime));
+
+                                      if (chosenTime != null) {
+                                        setState(() {
+                                          endDateTime = DateTime(
+                                              endDateTime.year,
+                                              endDateTime.month,
+                                              endDateTime.day,
+                                              chosenTime.hour,
+                                              chosenTime.minute);
+                                        });
+                                      }
+                                    },
+                                    child: Text(
+                                        "End: ${timeFormat.format(endDateTime)}",
                                         style: TextStyle(
                                             color: Theme.of(context)
                                                 .colorScheme
@@ -270,16 +315,18 @@ class _ItemPageState extends State<ItemPage> {
                       TextFormField(
                           controller: locationController,
                           style: TextStyle(
-                              color: Theme.of(context).colorScheme.tertiary,
-                              fontSize: 20),
+                            color: Theme.of(context).colorScheme.tertiary,
+                            // fontSize: 20
+                          ),
                           decoration: const InputDecoration(
                               hintText: "Location ...",
                               border: InputBorder.none)),
                       TextFormField(
                           controller: linkController,
                           style: TextStyle(
-                              color: Theme.of(context).colorScheme.tertiary,
-                              fontSize: 20),
+                            color: Theme.of(context).colorScheme.tertiary,
+                            // fontSize: 20
+                          ),
                           decoration: const InputDecoration(
                               hintText: "Link ...", border: InputBorder.none)),
                       Divider(color: Theme.of(context).colorScheme.tertiary),

--- a/lib/widgets/appbar.dart
+++ b/lib/widgets/appbar.dart
@@ -10,7 +10,7 @@ class MyAppBar extends StatelessWidget {
 
   const MyAppBar({
     super.key,
-    this.showAddButton = false,
+    this.showAddButton = true,
   });
 
   @override

--- a/lib/widgets/calendar/data_source.dart
+++ b/lib/widgets/calendar/data_source.dart
@@ -1,0 +1,64 @@
+import 'dart:ui';
+
+import 'package:syncfusion_flutter_calendar/calendar.dart';
+
+import '../../models/item.dart';
+
+/// This helper class decides how to read data from `ToDoItem`s into a
+/// calendar widget
+///
+///
+/// See also:
+/// - [TodoItem]
+/// - [MonthView]
+/// - [WeekView]
+class MeetingDataSource extends CalendarDataSource {
+  MeetingDataSource(List<TodoItem> source) {
+    appointments = source;
+  }
+
+  @override
+  Object? convertAppointmentToObject(
+      Object? customData, Appointment appointment) {
+    if (customData is TodoItem) {
+      print("nice");
+    } else {
+      print("bugger");
+    }
+
+    TodoItem item = customData as TodoItem;
+
+    return Appointment(
+        startTime: item.startTime!,
+        endTime: item.startTime!.add(const Duration(minutes: 30)));
+  }
+
+  @override
+  DateTime getStartTime(int index) {
+    return appointments![index].startTime;
+  }
+
+  // defaults all appointments to ~30 minutes (if null)
+  @override
+  DateTime getEndTime(int index) {
+    DateTime end =
+        appointments![index].startTime?.add(const Duration(minutes: 30));
+
+    return end;
+  }
+
+  @override
+  String getSubject(int index) {
+    return appointments![index].itemName;
+  }
+
+  @override
+  Color getColor(int index) {
+    return appointments![index].color;
+  }
+
+  @override
+  bool isAllDay(int index) {
+    return false;
+  }
+}

--- a/lib/widgets/calendar/month_view.dart
+++ b/lib/widgets/calendar/month_view.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:nudge/models/item.dart';
+import 'package:nudge/screens/item_page.dart';
+import 'package:provider/provider.dart';
+import 'package:syncfusion_flutter_calendar/calendar.dart';
+
+import '../../providers/calendar_provider.dart';
+import 'data_source.dart';
+
+/// a widget to show the user's to do list in a month-view calendar
+class MonthView extends StatefulWidget {
+  const MonthView({super.key});
+
+  @override
+  State<MonthView> createState() => _MonthViewState();
+}
+
+class _MonthViewState extends State<MonthView> {
+  final now = DateTime.now();
+
+  DateTime earliest = DateTime.now(), latest = DateTime.now();
+
+  @override
+  void initState() {
+    earliest = DateTime(now.year, now.month, 0);
+    latest = DateTime(now.year, now.month + 1, 1);
+    super.initState();
+  }
+
+  /// find the highest and lowest dates, and get all the dates between
+  void monthSelectionChanged(ViewChangedDetails viewChangedDetails) {
+    earliest = viewChangedDetails.visibleDates[0];
+    latest = viewChangedDetails.visibleDates[0];
+
+    // find the latest and earliest dates
+
+    viewChangedDetails.visibleDates.forEach((element) {
+      if (element.isBefore(earliest)) {
+        earliest = element;
+      }
+
+      if (element.isAfter(latest)) {
+        latest = element;
+      }
+    });
+
+    // add an extra day to latest to ensure it includes all events on the last visible day
+    latest.add(const Duration(days: 1));
+
+    print(earliest.toIso8601String());
+    print(latest.toIso8601String());
+
+    CalendarProvider().updateCalendarView(earliest, latest);
+  }
+
+  /// Open the corresponding `TodoItem` on a different screen, when an `Appointment`
+  /// is clicked
+  void onAppointmentClicked(CalendarTapDetails calendarTapDetails) {
+    if (calendarTapDetails.appointments != null &&
+        calendarTapDetails.appointments!.isNotEmpty) {
+      TodoItem item = calendarTapDetails.appointments?.first as TodoItem;
+      print(item.toMap());
+
+      Navigator.of(context)
+          .push(MaterialPageRoute(builder: (context) => ItemPage(item: item)));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(child: Consumer<CalendarProvider>(
+      builder: (context, provider, child) {
+        return SfCalendar(
+          initialDisplayDate: DateTime.now(),
+          showTodayButton: true,
+          allowedViews: [CalendarView.week, CalendarView.month],
+          view: CalendarView.month,
+          monthViewSettings: const MonthViewSettings(
+              showAgenda: true,
+              appointmentDisplayMode: MonthAppointmentDisplayMode.appointment),
+          showNavigationArrow: true,
+          onTap: (calendarTapDetails) =>
+              onAppointmentClicked(calendarTapDetails),
+          dataSource: MeetingDataSource(provider.itemsForMonth),
+          onViewChanged: (viewChangedDetails) {
+            monthSelectionChanged(viewChangedDetails);
+          },
+        );
+      },
+    ));
+  }
+}

--- a/lib/widgets/todo_list.dart
+++ b/lib/widgets/todo_list.dart
@@ -73,6 +73,10 @@ class _TodoListState extends State<TodoList> {
       positionItems();
     }
 
+    if (widget.items.isEmpty) {
+      return const Center(child: Text("You have no tasks for this day."));
+    }
+
     return Expanded(
       child: SizedBox(
         height: 200.0,

--- a/lib/widgets/todo_tile.dart
+++ b/lib/widgets/todo_tile.dart
@@ -48,7 +48,7 @@ class _ToDoTileState extends State<ToDoTile> {
 
                   // update the provider to show the item as deleted
                   ItemsProvider()
-                      .getItemsForDay(widget.item.time ?? DateTime.now());
+                      .getItemsForDay(widget.item.startTime ?? DateTime.now());
                   setState(() {});
                 },
                 icon: Icons.delete,
@@ -96,7 +96,7 @@ class _ToDoTileState extends State<ToDoTile> {
                     ),
                     Text(
                         DateFormat('MMM d HH:mm', 'en_US').format(
-                          widget.item.time ??
+                          widget.item.startTime ??
                               DateTime(DateTime.now().year,
                                   DateTime.now().month, DateTime.now().day),
                         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,17 +35,21 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+
+  # firestore
   firebase_core: ^2.6.1
   firebase_auth: ^4.4.1
-  intl: ^0.18.1
   cloud_firestore: ^4.4.2
+  intl: ^0.18.1
+
   flutter_cupertino_datetime_picker: ^3.0.0
-  flutter_slidable: ^3.0.0
   google_sign_in: ^6.1.4
   provider: ^6.0.5
-  flex_color_picker: ^3.3.0
-  syncfusion_flutter_calendar: ^22.2.11
- 
+
+  # widgets
+  flex_color_picker: ^3.3.0 # could implement this myself
+  syncfusion_flutter_calendar: ^22.2.11 # could implement this myself
+  flutter_slidable: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request adds some features to the calendar screen, including:

- [x] Add a week-view (kind of like a diary)
- [x] Add an end time to events
- [x] Add a way to enter the end time in the `ItemPage`
- [x] Clean up the `ItemPage` UI (font sizes)
- [x] Add a text message when there are no items for a given day